### PR TITLE
Nav header width fix

### DIFF
--- a/Redgram/app/src/main/res/layout/nav_header_main.xml
+++ b/Redgram/app/src/main/res/layout/nav_header_main.xml
@@ -2,7 +2,7 @@
 <!--include fixed header of nav drawer-->
 <FrameLayout
     android:id="@+id/userDrawerHeader"
-    android:layout_width="@dimen/navigation_drawer_width"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/navigation_drawer_personal_data_layout_height"
     android:background="@color/material_red400"
     xmlns:android="http://schemas.android.com/apk/res/android">


### PR DESCRIPTION
A simple fix for the nav header width, which caused it to look like this:
![before](https://cloud.githubusercontent.com/assets/6024783/18798324/49c9f77c-81d2-11e6-8926-a72aaacd654e.jpg)

Instead of this, which I suppose it's the intended look:
![after](https://cloud.githubusercontent.com/assets/6024783/18798334/5576183a-81d2-11e6-9cde-d626eeeb79a2.jpg)
